### PR TITLE
fix LDFLAGS mac build issue; add support for docker push to harness gcr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ pkged.go
 !/.idea/externalDependencies.xml
 !/.idea/go.imports.xml
 !/.idea/modules.xml
-!/.idea/runConfigurations/
 !/.idea/scopes/
 !/.idea/sqldialects.xml
 

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,15 @@ OS = $(shell uname | tr A-Z a-z)
 BUILD_PACKAGE ?= ./cmd/cloudinfo
 BINARY_NAME ?= cloudinfo
 DOCKER_IMAGE = banzaicloud/cloudinfo
+GCR_PROJECT_ID ?= platform-205701
 
 # Build variables
 BUILD_DIR ?= build
-VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)
+VERSION ?= $(shell git symbolic-ref -q --short HEAD | sed 's/[^a-zA-Z0-9]/-/g')
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE ?= $(shell date +%FT%T%z)
-LDFLAGS += -X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH} -X main.buildDate=${BUILD_DATE}
+BRANCH ?= $(shell git symbolic-ref -q --short HEAD)
+LDFLAGS := -X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH} -X main.buildDate=${BUILD_DATE} -X main.branch=${BRANCH}
 export CGO_ENABLED ?= 0
 ifeq (${VERBOSE}, 1)
 ifeq ($(filter -v,${GOARGS}),)

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -66,6 +66,7 @@ var (
 	version    string
 	commitHash string
 	buildDate  string
+	branch     string
 )
 
 func main() {
@@ -79,7 +80,7 @@ func main() {
 	_ = p.Parse(os.Args[1:])
 
 	if v, _ := p.GetBool("version"); v {
-		fmt.Printf("%s version %s (%s) built on %s\n", friendlyAppName, version, commitHash, buildDate)
+		fmt.Printf("%s version %s (%s) built on %s at %s\n", friendlyAppName, version, commitHash, branch, buildDate)
 
 		os.Exit(0)
 	}
@@ -150,7 +151,7 @@ func main() {
 	errorHandler := errorhandler.New(logger)
 	defer emperror.HandleRecover(errorHandler)
 
-	buildInfo := buildinfo.New(version, commitHash, buildDate)
+	buildInfo := buildinfo.New(version, commitHash, buildDate, branch)
 
 	logger.Info("starting application", buildInfo.Fields())
 

--- a/internal/platform/buildinfo/buildinfo.go
+++ b/internal/platform/buildinfo/buildinfo.go
@@ -36,7 +36,7 @@ func New(version string, commitHash string, buildDate string, branch string) Bui
 		Version:    version,
 		CommitHash: commitHash,
 		BuildDate:  buildDate,
-		Branch: 	branch,
+		Branch:     branch,
 		GoVersion:  runtime.Version(),
 		Os:         runtime.GOOS,
 		Arch:       runtime.GOARCH,

--- a/internal/platform/buildinfo/buildinfo.go
+++ b/internal/platform/buildinfo/buildinfo.go
@@ -23,6 +23,7 @@ type BuildInfo struct {
 	Version    string `json:"version"`
 	CommitHash string `json:"commit_hash"`
 	BuildDate  string `json:"build_date"`
+	Branch     string `json:"branch"`
 	GoVersion  string `json:"go_version"`
 	Os         string `json:"os"`
 	Arch       string `json:"arch"`
@@ -30,11 +31,12 @@ type BuildInfo struct {
 }
 
 // New returns all available build information.
-func New(version string, commitHash string, buildDate string) BuildInfo {
+func New(version string, commitHash string, buildDate string, branch string) BuildInfo {
 	return BuildInfo{
 		Version:    version,
 		CommitHash: commitHash,
 		BuildDate:  buildDate,
+		Branch: 	branch,
 		GoVersion:  runtime.Version(),
 		Os:         runtime.GOOS,
 		Arch:       runtime.GOARCH,
@@ -48,6 +50,7 @@ func (bi BuildInfo) Fields() map[string]interface{} {
 		"version":     bi.Version,
 		"commit_hash": bi.CommitHash,
 		"build_date":  bi.BuildDate,
+		"branch":      bi.Branch,
 		"go_version":  bi.GoVersion,
 		"os":          bi.Os,
 		"arch":        bi.Arch,

--- a/main-targets.mk
+++ b/main-targets.mk
@@ -59,7 +59,12 @@ docker: ## Build a Docker image
 	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
 ifeq (${DOCKER_LATEST}, 1)
 	docker tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_IMAGE}:latest
+	docker tag ${DOCKER_IMAGE}:${DOCKER_TAG} gcr.io/${GCR_PROJECT_ID}/${DOCKER_IMAGE}:${DOCKER_TAG}
 endif
+
+.PHONY: docker-push
+docker-push: ## Push Docker image to GCR
+	docker push gcr.io/${GCR_PROJECT_ID}/${DOCKER_IMAGE}:${DOCKER_TAG}
 
 .PHONY: docker-debug
 docker-debug: ## Build a Docker image with remote debugging capabilities

--- a/main-targets.mk
+++ b/main-targets.mk
@@ -121,6 +121,10 @@ lint: bin/golangci-lint ## Run linter
 fix: bin/golangci-lint ## Fix lint violations
 	bin/golangci-lint run --fix
 
+.PHONY: fmt
+fmt: ## Fix go fmt
+	@gofmt -s -w ${GOFILES_NOVENDOR}
+
 bin/licensei: bin/licensei-${LICENSEI_VERSION}
 	@ln -sf licensei-${LICENSEI_VERSION} bin/licensei
 bin/licensei-${LICENSEI_VERSION}:


### PR DESCRIPTION
Making cloudInfo suitable for env based testing.
This doesn’t need a build pipeline, can be built locally and pushed to harness GCR registry.
Tag: [utsav-setup-build-metadata](gcr.io/platform-205701/banzaicloud/cloudinfo@sha256:aea43942d14f08c2f82daffe2d0ff3e1f980f90d3498ee987685b77181f18f7e)
1. `make fmt` # fix static issue, gofmt
2. fix Makefile to support macos
3. `make docker-push` to push to Harness GCR platform-205701