### PR TITLE
feat: [SMP-1967]: added common annotations and labels

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cloud-info.labels" . | nindent 4 }}
+    {{- if .Values.global.commonLabels }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.commonAnnotations }}
+  annotations: {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -19,13 +25,24 @@ spec:
       {{- include "cloud-info.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.global.commonAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.podAnnotations }}
+          {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.commonAnnotations }}
+          {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         app: ce-cloud-info
         {{- include "cloud-info.selectorLabels" . | nindent 8 }}
+        {{- if .Values.global.commonLabels }}
+        {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.podLabels }}
+        {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "cloud-info.pullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "cloud-info.serviceAccountName" . }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -3,9 +3,22 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cloud-info
+   {{- if .Values.global.commonLabels }}
+  labels:
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- if .Values.ingress.annotations }}
+      {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.commonAnnotations }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.ingress.objects.annotations }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.ingress.objects.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:

--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -3,6 +3,14 @@ kind: PodDisruptionBudget
 metadata:
   name: cloud-info
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.commonLabels }}
+  labels:
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.global.commonAnnotations }}
+  annotations:
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   minAvailable: 1
   selector:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cloud-info.labels" . | nindent 4 }}
+    {{- if .Values.global.commonLabels }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.commonAnnotations }}
+  annotations:
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
 {{- include "cloud-info.generateMountSecrets" . }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -5,6 +5,18 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cloud-info.labels" . | nindent 4 }}
+    {{- if .Values.global.commonLabels }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.global.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.service.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.commonAnnotations }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -6,8 +6,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cloud-info.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+    {{- if .Values.global.commonLabels }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.serviceAccount.annotations .Values.global.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.serviceAccount.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.commonAnnotations }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/virtualservice.yaml
+++ b/chart/templates/virtualservice.yaml
@@ -7,6 +7,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.global.commonLabels }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.virtualService.annotations }}
+    {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.virtualService.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.commonAnnotations }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   gateways:
     {{- if .Values.global.istio.gateway.create }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 global:
   loadbalancerURL: "https://test"
+  commonAnnotations: {}
+  commonLabels: {}
   ingress:
     enabled: false
     className: harness
@@ -50,17 +52,23 @@ serviceAccount:
   name: "harness-default"
 
 podAnnotations: {}
+podLabels: {}
 
 podSecurityContext: {}
 
 securityContext: {}
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 8082
   targetPort: 8000
 
+virtualService:
+  annotations: {}
+
 ingress:
+  annotations: {}
   className: nginx
 
 autoscaling:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes SMP-1967, partially SMP-1216
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds the option to add common annotations and labels to all the chart resources. There is a requirement to annotate or label all the services to work with certain cloud provider settings, currently, the process is tedious which is adding annotations to each of the services separately. With this PR, it can be added as a global override to all the charts.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Testing
I have tested the changes by doing helm template with different configuration combinations and the charts template without any error.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

