### PR TITLE
feat: [PL-56709]: Updating PDB in services chart 

### DIFF
--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -1,18 +1,1 @@
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cloud-info
-  namespace: {{ .Release.Namespace }}
-  {{- if .Values.global.commonLabels }}
-  labels:
-    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
-  {{- end }}
-  {{- if .Values.global.commonAnnotations }}
-  annotations:
-    {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      {{- include "cloud-info.selectorLabels" . | nindent 6 }}
+{{- include "harnesscommon.pdb.renderPodDistributionBudget" (dict "ctx" $) }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 global:
+  pdb:
+    create: false
   loadbalancerURL: "https://test"
   commonAnnotations: {}
   commonLabels: {}
@@ -173,3 +175,6 @@ config:
 
 rbac:
   rules: []
+
+pdb:
+  create: false


### PR DESCRIPTION
Pod Disruption Budgets are not configurable and for most of the services are set at minAvailable: 50%, customers require an option to configure PDBs for all services and the ability to turn them off or on.
This PR updates the PDB manifest to use the helm-common function for rendering the PDB manifest and is configurable through the override file.
The configuration is divided into two parts Global:

Global configurations will be applied to all services
Local: These have precedence over global config and can be used to specifically set values for the PDB of a service.