### PR TITLE
[fix]: [CCM-20083]: cloud-info- Remove the /status logging as error

### DIFF
--- a/internal/platform/log/middleware.go
+++ b/internal/platform/log/middleware.go
@@ -92,8 +92,11 @@ func Middleware(notlogged ...string) gin.HandlerFunc {
 
 		c.Next()
 
-		// Log only when path is not being skipped
 		if _, ok := skip[path]; !ok {
+			if path == "/status" && c.Writer.Status() == 200 {
+				return
+			}
+
 			end := time.Now()
 			latency := end.Sub(start)
 
@@ -118,7 +121,7 @@ func Middleware(notlogged ...string) gin.HandlerFunc {
 
 			entry := logrus.WithFields(fields)
 
-			if len(c.Errors) > 0 {
+			if c.Writer.Status() >= 400 && len(c.Errors) > 0 {
 				// Append error field if this is an erroneous request.
 				entry.Error(c.Errors.String())
 			} else {


### PR DESCRIPTION
Remove the log lines like 

ERROR 2024-11-06T05:13:35.492237536Z time="2024-11-06T05:13:35Z" level=info correlation-id=fa468101-7fe5-4d40-a2b5-ef05d17fe0ca latency="48.15µs" method=GET path=/status status=200


```
{
insertId: "mpsn16xz6f5kma2e"
labels: {5}
logName: "projects/qa-setup/logs/stderr"
receiveTimestamp: "2024-11-06T05:13:38.671402819Z"
resource: {
labels: {
cluster_name: "qa-private"
container_name: "cloud-info"
location: "us-west1"
namespace_name: "harness-helm-new"
pod_name: "cloud-info-5cff696789-jr4m4"
project_id: "qa-setup"
}
type: "k8s_container"
}
severity: "ERROR"
textPayload: "time="2024-11-06T05:13:35Z" level=info correlation-id=fa468101-7fe5-4d40-a2b5-ef05d17fe0ca latency="48.15µs" method=GET path=/status status=200"
timestamp: "2024-11-06T05:13:35.492237536Z"
}
```

This will not remove the log lines like 
INFO 2024-11-06T06:16:01.681166365Z [GIN] 2024/11/06 - 06:16:01 | 200 | 88.83µs | 10.64.1.129 | GET "/status"

As that would require to disable Gin's default logging middleware, gin.Logger(), as it is responsible for these [GIN] logs
Also note that the PR [[fix]: [CCM-20084]: Update the livenessProbe and readinessProbe intervals](https://github.com/wings-software/cloudinfo/pull/775) will fix the frequency of the /status check.

Testing: https://cloudlogging.app.goo.gl/TspMBw7FEzdZ6YgD6

[CCM-20084]: https://harness.atlassian.net/browse/CCM-20084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ